### PR TITLE
New container for an upcoming PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - docker pull nfcore/nascent:dev
   # Fake the tag locally so that the pipeline runs properly
   # Looks weird when this is :dev to :dev, but makes sense when testing code for a release (:dev to :1.0.1)
-  - docker tag nfcore/nascent:dev nfcore/nascent:1.0
+  - docker tag nfcore/nascent:dev nfcore/nascent:dev
 
 install:
   # Install Nextflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # nf-core/nascent: Changelog
 
+## v1.0.2 - 2020-05-21
+Bumped FastQC version, to produce a new container image for the upcoming PR to become v1.1.
+
 ## v1.0.1 - 2020-03-03
 Update to the container to meet the latest template requirements, and dependencies for new features in an upcoming PR (R and Picard tools).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ LABEL authors="Ignacio Tripodi (ignacio.tripodi@colorado.edu), Margaret Gruca (m
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/nf-core-nascent-1.0/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-nascent-1.0.2dev/bin:$PATH

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - conda-forge::markdown=3.1.1
   - conda-forge::pymdown-extensions=6.0
   - conda-forge::pygments=2.5.2
-  - fastqc=0.11.8
+  - fastqc=0.11.9
   - multiqc=1.7
   - hisat2=2.1.0
   - samtools=1.9

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: nf-core-nascent-1.1
+name: nf-core-nascent-1.0.2dev
 channels:
   - conda-forge
   - bioconda

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,7 +60,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nfcore/nascent:1.0'
+process.container = 'nfcore/nascent:dev'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -113,7 +113,7 @@ manifest {
   description = 'Nascent Transcription Processing Pipeline'
   mainScript = 'main.nf'
   nextflowVersion = '>=0.32.0'
-  version = '1.0'
+  version = '1.0.2dev'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
Bumping FastQC's version to both take advantage of the newer tool, and generate a new container to get ready for an upcoming major PR. Updated the environment and changelog files accordingly, and any additional changes incorporated after running `--bump-version` to `1.0.2dev`.

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [X] Make sure your code lints (`nf-core lint .`).
 - [X] `CHANGELOG.md` is updated
