### PR TITLE
fix(test): use small reference for MiniBWA

### DIFF
--- a/workflows/tests/aligner/minibwa.nf.test
+++ b/workflows/tests/aligner/minibwa.nf.test
@@ -5,7 +5,7 @@ nextflow_pipeline {
     tag "aligner"
     tag "minibwa"
 
-    test("Should run with defaults") {
+    test("Should build a small index and align reads") {
         // PINTS can fail on tiny MiniBWA test BAMs; this test covers aligner wiring.
         config '../skip_pints.config'
 
@@ -14,6 +14,9 @@ nextflow_pipeline {
                 outdir = "$outputDir"
                 aligner = "minibwa"
                 input = "${projectDir}/assets/samplesheet.csv"
+                genome = null
+                fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/nascent/reference/GRCh38_chr21.fa'
+                gtf = 'https://raw.githubusercontent.com/nf-core/test-datasets/nascent/reference/genes_chr21.gtf.gz'
             }
         }
 

--- a/workflows/tests/skip_pints.config
+++ b/workflows/tests/skip_pints.config
@@ -2,6 +2,10 @@
 aws.client.anonymous = true
 
 process {
+    withName: '.*:PINTS_VISUALIZER' {
+        ext.when = false
+    }
+
     withName: '.*:TRANSCRIPT_INDENTIFICATION:.*' {
         ext.when = false
     }


### PR DESCRIPTION
## Summary
- run the MiniBWA pipeline test against the chr21 nascent reference instead of full hg38
- make the existing `skip_pints.config` actually skip `PINTS_VISUALIZER`

## Verification
- Nextflow 25.10.4, `debug,test,docker`: pipeline completed successfully with MiniBWA index construction and alignment
- commit hooks passed

Fixes the resource failure observed after #221 without removing MiniBWA.